### PR TITLE
Fix Markdown version in build

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           python-version: 3.x
       - name: Prepare system
-        run: 	pip install --user  mkdocs  mkdocs-material  pymdown-extensions pygments markdown-blockdiag mkdocs-bibtex markdown-aafigure==v201904.0004 mkdocs-build-plantuml-plugin 'Pillow<10'
+        run: pip install --user mkdocs mkdocs-material pymdown-extensions pygments markdown-blockdiag mkdocs-bibtex markdown-aafigure==v201904.0004 mkdocs-build-plantuml-plugin 'Pillow<10' 'Markdown<3.4'
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Pages

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 prepare:
-	pip install --user mkdocs mkdocs-material pymdown-extensions pygments markdown-blockdiag mkdocs-bibtex markdown-aafigure==v201904.0004 mkdocs-build-plantuml-plugin 'Pillow<10'
+	pip install --user mkdocs mkdocs-material pymdown-extensions pygments markdown-blockdiag mkdocs-bibtex markdown-aafigure==v201904.0004 mkdocs-build-plantuml-plugin 'Pillow<10' 'Markdown<3.4'
 
 serve:
 	mkdocs serve

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Install the necessary libraries locally:
 ```
 $ pip install --user mkdocs mkdocs-material pymdown-extensions pygments \
                      markdown-blockdiag mkdocs-bibtex markdown-aafigure==v201904.0004 \
-                     mkdocs-build-plantuml-plugin 'Pillow<10'
+                     mkdocs-build-plantuml-plugin 'Pillow<10' 'Markdown<3.4'
 ```
 
 You can start development web-server, which automatically rerender and refresh

--- a/docs/devel/howtodoc/index.md
+++ b/docs/devel/howtodoc/index.md
@@ -22,7 +22,7 @@ use either `make prepare` or execute the following line:
 ``` {.sh linenums="1"}
 $ pip install --user mkdocs mkdocs-material pymdown-extensions pygments \
                      markdown-blockdiag mkdocs-bibtex markdown-aafigure==v201904.0004 \
-                     mkdocs-build-plantuml-plugin 'Pillow<10'
+                     mkdocs-build-plantuml-plugin 'Pillow<10' 'Markdown<3.4'
 ```
 
 This install all needed packages for this webpage inside


### PR DESCRIPTION
cc @WolframPfeifer

See https://python-markdown.github.io/change_log/release-3.4/#previously-deprecated-objects-have-been-removed / https://github.com/gisce/markdown-blockdiag/pull/16